### PR TITLE
Add placeholder comment for world setup in ConfigFile

### DIFF
--- a/src/main/java/eu/minehome/minehomelobby/manager/ConfigFile.java
+++ b/src/main/java/eu/minehome/minehomelobby/manager/ConfigFile.java
@@ -1,5 +1,6 @@
 package eu.minehome.minehomelobby.manager;
 
 public class ConfigFile {
+    //Gebe deine eigene Welt an
     //Create Config File for setup stuff
 }


### PR DESCRIPTION
Added a placeholder comment to indicate where world setup logic will be implemented. This prepares the file for future functionality and improves code organization.